### PR TITLE
Remove dependency on the host project's Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,9 +105,10 @@ val sbtPlugin = project("sbt-sangria-codegen")
     scriptedSettings,
     // scriptedBufferLog := false,
     scriptedLaunchOpts += "-Dproject.version=" + version.value,
-    // Dynamically set the Scala version to match what publishLocal provides.
-    scriptedLaunchOpts += "-Dscala.version=" + (scalaVersion in ThisBuild).value,
-    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoKeys := Seq[BuildInfoKey](
+      version,
+      scalaVersion in ThisBuild,
+      scalaBinaryVersion in ThisBuild),
     buildInfoPackage := "com.mediative.sangria.codegen.sbt"
   )
 

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate/build.sbt
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate/build.sbt
@@ -1,6 +1,6 @@
 name := "test"
 enablePlugins(SangriaCodegenPlugin)
-scalaVersion := sys.props("scala.version")
+scalaVersion := "2.11.11"
 
 TaskKey[Unit]("check") := {
   val file = (sangriaCodegen in Compile).value


### PR DESCRIPTION
Explicitly declare the required Scala version so the plugin won't
default to the Scala version of the "host project".