### PR TITLE
Add sbt plugin for generating schema via introspection

### DIFF
--- a/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaCodegenPlugin.scala
+++ b/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaCodegenPlugin.scala
@@ -56,8 +56,8 @@ import sbt.Keys._
  *
  * @example
  * {{{
- * sangriaCodegenSchema := sourceDirectory.value / "graphql" / "schema.graphql"
- * sangriaCodegenQueries += sourceDirectory.value / "graphql" / "api.graphql"
+ * sangriaCodegenSchema in Compile := sourceDirectory.value / "graphql" / "schema.graphql"
+ * sangriaCodegenQueries in Compile += sourceDirectory.value / "graphql" / "api.graphql"
  * }}}
  */
 object SangriaCodegenPlugin extends AutoPlugin {

--- a/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
+++ b/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.sbt
+
+import sbt._
+import sbt.Keys._
+
+/**
+ * Generate GraphQL schema file from a Sangria schema instance.
+ *
+ * == Usage ==
+ *
+ * This plugin must be explicitly enabled. To enable it add the following line
+ * to your `.sbt` file:
+ * {{{
+ * enablePlugins(SangriaSchemagenPlugin)
+ * }}}
+ *
+ * In addition, it is required to configure `sangriaSchemagenCode` with a snippet
+ * of Scala code providing access to your `sangria.schema.Schema[_, _]`.
+ *
+ * See the [[https://github.com/mediative/sangria-codegen/tree/master/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema example project]].
+ *
+ * == Using with [[SangriaCodegenPlugin]] ==
+ *
+ * To use this plugin to generate a schema for use with [[SangriaCodegenPlugin]]
+ * they must be configured in separate projects. For example, [[SangriaSchemagenPlugin]]
+ * could be enabled in the server project which defines the Sangria schema, and
+ * [[SangriaCodegenPlugin]] will be enabled in the client project which consumes
+ * the GraphQL services.
+ *
+ * See the [[https://github.com/mediative/sangria-codegen/tree/master/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code example project]].
+ *
+ * == Implementation Details ==
+ *
+ * The plugins introduces a parallel build scope named `sangria-schemagen` and
+ * uses it for generating a program for executing the schema introspection code
+ * defined in `sangriaSchemagenSnippet`. The build scope depends on the normal
+ * `compile` scope so schema classes are available when running the program.
+ * Generate code can be found in `target/scala-2.x/src_managed/sangria-schemagen`
+ * and compile artifacts can be found in `target/scala-2.x/sangria-schemagen-classes`.
+ *
+ * == Configuration ==
+ *
+ * Keys are defined in [[SangriaSchemagenPlugin.autoImport]].
+ *
+ *  - `sangriaSchemagenSnippet`: Code snippet to access the Sangria Schema.
+ *  - `sangriaSchemagenSchema`: GraphQL schema output file. Defaults to
+ *    file located inside `resourceManaged`.
+ *  - `sangriaSchemagen`: Generate the GraphQL schema file.
+ *
+ * @example
+ * {{{
+ * sangriaSchemagenSnippet in Compile := Some("com.example.schema.GraphqlSchema")
+ * sangriaSchemagenSchema in Compile := (resourceDirectory in Compile).value / "schema.graphql"
+ * }}}
+ */
+object SangriaSchemagenPlugin extends AutoPlugin {
+
+  object autoImport {
+    val SangriaSchemagen        = config("sangria-schemagen") extend Compile
+    val sangriaSchemagenSnippet = taskKey[Option[String]]("Code to access the Sangria schema")
+    val sangriaSchemagenSchema  = taskKey[File]("GraphQL schema output file")
+    val sangriaSchemagen        = taskKey[File]("Generate GraphQL schema file")
+  }
+  import autoImport._
+
+  override def requires = plugins.JvmPlugin
+
+  override def projectSettings: Seq[Setting[_]] =
+    sangriaSchemagenScopedSettings(SangriaSchemagen, Compile) ++
+      sangriaSchemagenDefaultSettings
+
+  def sangriaSchemagenDefaultSettings: Seq[Setting[_]] = Seq(
+    ivyConfigurations += SangriaSchemagen
+  )
+
+  def sangriaSchemagenScopedSettings(
+      introspection: Configuration,
+      runtime: Configuration): Seq[Setting[_]] = {
+    val mainName    = introspection.name.split("-").map(_.capitalize).mkString
+    val packageName = "com.mediative.sangria.codegen"
+    val mainClass   = packageName + "." + mainName
+
+    inConfig(runtime)(
+      Seq(
+        sangriaSchemagenSnippet := None,
+        sangriaSchemagenSchema := resourceManaged.value / "sbt-sangria-codegen" / "schema.graphql",
+        sangriaSchemagen := {
+          val schemaFile = sangriaSchemagenSchema.value
+
+          (runner in (introspection, run)).value.run(
+            mainClass,
+            Attributed.data((fullClasspath in introspection).value),
+            List(schemaFile.getAbsolutePath),
+            streams.value.log
+          )
+
+          streams.value.log.info("Generating schema in $schemaFile")
+          schemaFile
+        }
+      )
+    ) ++
+      inConfig(introspection)(
+        Defaults.compileSettings ++
+          Seq(
+            sourceGenerators += Def.task {
+              val schemaCode = (sangriaSchemagenSnippet in runtime).value
+              val file       = sourceManaged.value / "sbt-sangria-codegen" / s"$mainName.scala"
+
+              if (!schemaCode.isDefined)
+                sys.error(
+                  "compile:sangriaSchemagenSnippet should contain a code snippet to access the Sangria schema")
+
+              val content = s"""
+                package $packageName
+
+                object $mainName {
+                  val schema: sangria.schema.Schema[_, _] = {
+                    ${schemaCode.get}
+                  }
+
+                  def main(args: Array[String]): Unit = {
+                    val schemaFile = new java.io.File(args(0))
+                    val graphql: String = schema.renderPretty
+                    schemaFile.getParentFile.mkdirs()
+                    new java.io.PrintWriter(schemaFile) {
+                      write(graphql)
+                      close
+                    }
+                  }
+                }
+              """
+
+              if (!file.exists || IO.read(file) != content)
+                IO.write(file, content)
+
+              Seq(file)
+            }
+          )
+      )
+  }
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/build.sbt
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/build.sbt
@@ -1,0 +1,33 @@
+name := "test"
+scalaVersion in ThisBuild := "2.12.3"
+
+val StarWarsDir = file(sys.props("samples.dir")) / "starwars"
+
+val server = project
+  .enablePlugins(SangriaSchemagenPlugin)
+  .settings(
+    libraryDependencies += "org.sangria-graphql" %% "sangria" % "1.2.2",
+    sangriaSchemagenSnippet in Compile := Some(
+      "com.mediative.sangria.codegen.starwars.TestSchema.StarWarsSchema")
+  )
+
+val client = project
+  .enablePlugins(SangriaCodegenPlugin)
+  .settings(
+    sangriaCodegenSchema in Compile := (sangriaSchemagen in (server, Compile)).value,
+    resourceDirectories in (Compile, sangriaCodegen) += StarWarsDir,
+    includeFilter in (Compile, sangriaCodegen) := "MultiQuery.graphql",
+    name in (Compile, sangriaCodegen) := "MultiQueryApi"
+  )
+
+TaskKey[Unit]("check") := {
+  val file     = (sangriaCodegen in (client, Compile)).value
+  val expected = StarWarsDir / "MultiQuery.scala"
+
+  assert(file.exists)
+
+  val compare = IO.read(file).trim == IO.read(expected).trim
+  if (!compare)
+    s"diff -u $expected $file".!
+  assert(compare, s"$file does not equal $expected")
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/project/plugins.sbt
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.mediative" % "sbt-sangria-codegen" % sys.props("project.version"))

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/server/src/main/scala/com.mediative.sangria.codegen.starwars/TestData.scala
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/server/src/main/scala/com.mediative.sangria.codegen.starwars/TestData.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Oleg Ilyenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.starwars
+
+import sangria.execution.deferred.{Deferred, DeferredResolver}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+object TestData {
+  object Episode extends Enumeration {
+    val NEWHOPE, EMPIRE, JEDI = Value
+  }
+
+  trait Character {
+    def id: String
+    def name: Option[String]
+    def friends: List[String]
+    def appearsIn: List[Episode.Value]
+  }
+
+  case class Human(
+      id: String,
+      name: Option[String],
+      friends: List[String],
+      appearsIn: List[Episode.Value],
+      homePlanet: Option[String])
+      extends Character
+  case class Droid(
+      id: String,
+      name: Option[String],
+      friends: List[String],
+      appearsIn: List[Episode.Value],
+      primaryFunction: Option[String])
+      extends Character
+
+  case class DeferFriends(friends: List[String]) extends Deferred[List[Option[Character]]]
+
+  val characters = List[Character](
+    Human(
+      id = "1000",
+      name = Some("Luke Skywalker"),
+      friends = List("1002", "1003", "2000", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Tatooine")
+    ),
+    Human(
+      id = "1001",
+      name = Some("Darth Vader"),
+      friends = List("1004"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Tatooine")),
+    Human(
+      id = "1002",
+      name = Some("Han Solo"),
+      friends = List("1000", "1003", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = None),
+    Human(
+      id = "1003",
+      name = Some("Leia Organa"),
+      friends = List("1000", "1002", "2000", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Alderaan")
+    ),
+    Human(
+      id = "1004",
+      name = Some("Wilhuff Tarkin"),
+      friends = List("1001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = None),
+    Droid(
+      id = "2000",
+      name = Some("C-3PO"),
+      friends = List("1000", "1002", "1003", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      primaryFunction = Some("Protocol")
+    ),
+    Droid(
+      id = "2001",
+      name = Some("R2-D2"),
+      friends = List("1000", "1002", "1003"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      primaryFunction = Some("Astromech")
+    )
+  )
+
+  class FriendsResolver extends DeferredResolver[Any] {
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(
+        implicit ec: ExecutionContext) = deferred map {
+      case DeferFriends(friendIds) ⇒
+        Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
+    }
+  }
+
+  class CharacterRepo {
+    def getHero(episode: Option[Episode.Value]) =
+      episode flatMap (_ ⇒ getHuman("1000")) getOrElse characters.last
+
+    def getHuman(id: String): Option[Human] =
+      characters.find(c ⇒ c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
+
+    def getDroid(id: String): Option[Droid] =
+      characters.find(c ⇒ c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
+
+    def getCharacters(ids: Seq[String]): Seq[Character] =
+      ids.flatMap(id ⇒ characters.find(_.id == id))
+  }
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/server/src/main/scala/com.mediative.sangria.codegen.starwars/TestSchema.scala
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/server/src/main/scala/com.mediative.sangria.codegen.starwars/TestSchema.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 Oleg Ilyenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.starwars
+
+import sangria.execution.UserFacingError
+import sangria.schema._
+
+import scala.concurrent.Future
+
+object TestSchema {
+  import TestData._
+
+  case class PrivacyError(message: String) extends Exception(message) with UserFacingError
+
+  val EpisodeEnum = EnumType(
+    "Episode",
+    Some("One of the films in the Star Wars Trilogy"),
+    List(
+      EnumValue(
+        "NEWHOPE",
+        value = TestData.Episode.NEWHOPE,
+        description = Some("Released in 1977.")),
+      EnumValue("EMPIRE", value = TestData.Episode.EMPIRE, description = Some("Released in 1980.")),
+      EnumValue("JEDI", value = TestData.Episode.JEDI, description = Some("Released in 1983."))))
+
+  val Character: InterfaceType[Unit, TestData.Character] =
+    InterfaceType(
+      "Character",
+      "A character in the Star Wars Trilogy",
+      () ⇒
+        fields[Unit, TestData.Character](
+          Field("id", StringType, Some("The id of the character."), resolve = _.value.id),
+          Field(
+            "name",
+            OptionType(StringType),
+            Some("The name of the character."),
+            resolve = _.value.name),
+          Field(
+            "friends",
+            OptionType(ListType(OptionType(Character))),
+            Some("The friends of the character, or an empty list if they have none."),
+            resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+          ),
+          Field(
+            "appearsIn",
+            OptionType(ListType(OptionType(EpisodeEnum))),
+            Some("Which movies they appear in."),
+            resolve = _.value.appearsIn map (e ⇒ Some(e))),
+          Field(
+            "secretBackstory",
+            OptionType(StringType),
+            Some("Where are they from and how they came to be who they are."),
+            resolve = _ ⇒ throw PrivacyError("secretBackstory is secret.")
+          )
+      ))
+
+  val Human =
+    ObjectType(
+      "Human",
+      "A humanoid creature in the Star Wars universe.",
+      interfaces[Unit, Human](PossibleInterface[Unit, Human](Character)),
+      fields[Unit, Human](
+        Field("id", StringType, Some("The id of the human."), resolve = _.value.id),
+        Field(
+          "name",
+          OptionType(StringType),
+          Some("The name of the human."),
+          resolve = _.value.name),
+        Field(
+          "friends",
+          OptionType(ListType(OptionType(Character))),
+          Some("The friends of the human, or an empty list if they have none."),
+          resolve = (ctx) ⇒ DeferFriends(ctx.value.friends)
+        ),
+        Field(
+          "appearsIn",
+          OptionType(ListType(OptionType(EpisodeEnum))),
+          Some("Which movies they appear in."),
+          resolve = _.value.appearsIn map (e ⇒ Some(e))),
+        Field(
+          "homePlanet",
+          OptionType(StringType),
+          Some("The home planet of the human, or null if unknown."),
+          resolve = _.value.homePlanet)
+      )
+    )
+
+  val Droid = ObjectType(
+    "Droid",
+    "A mechanical creature in the Star Wars universe.",
+    interfaces[Unit, Droid](PossibleInterface[Unit, Droid](Character)),
+    fields[Unit, Droid](
+      Field(
+        "id",
+        StringType,
+        Some("The id of the droid."),
+        tags = ProjectionName("_id") :: Nil,
+        resolve = _.value.id),
+      Field(
+        "name",
+        OptionType(StringType),
+        Some("The name of the droid."),
+        resolve = ctx ⇒ Future.successful(ctx.value.name)),
+      Field(
+        "friends",
+        OptionType(ListType(OptionType(Character))),
+        Some("The friends of the droid, or an empty list if they have none."),
+        resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+      ),
+      Field(
+        "appearsIn",
+        OptionType(ListType(OptionType(EpisodeEnum))),
+        Some("Which movies they appear in."),
+        resolve = _.value.appearsIn map (e ⇒ Some(e))),
+      Field(
+        "primaryFunction",
+        OptionType(StringType),
+        Some("The primary function of the droid."),
+        resolve = _.value.primaryFunction)
+    )
+  )
+
+  val ID = Argument("id", StringType, description = "id of the character")
+
+  val EpisodeArg = Argument(
+    "episode",
+    OptionInputType(EpisodeEnum),
+    description =
+      "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.")
+
+  val Query = ObjectType[CharacterRepo, Unit](
+    "Query",
+    fields[CharacterRepo, Unit](
+      Field(
+        "hero",
+        Character,
+        arguments = EpisodeArg :: Nil,
+        resolve = (ctx) ⇒ ctx.ctx.getHero(ctx.arg(EpisodeArg))),
+      Field(
+        "human",
+        OptionType(Human),
+        arguments = ID :: Nil,
+        resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
+      Field(
+        "droid",
+        Droid,
+        arguments = ID :: Nil,
+        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+    ))
+
+  val StarWarsSchema = Schema(Query)
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/test
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code/test
@@ -1,0 +1,3 @@
+> update
+> check
+> client/compile

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/build.sbt
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/build.sbt
@@ -1,0 +1,28 @@
+name := "test"
+enablePlugins(SangriaSchemagenPlugin)
+scalaVersion := "2.12.3"
+
+libraryDependencies += "org.sangria-graphql" %% "sangria" % "1.2.2"
+
+val StarWarsDir = file(sys.props("samples.dir")) / "starwars"
+
+sangriaSchemagenSnippet in Compile := Some(
+  "com.mediative.sangria.codegen.starwars.TestSchema.StarWarsSchema")
+
+TaskKey[Unit]("checkBefore") := {
+  val schemaFile = (sangriaSchemagenSchema in Compile).value
+  assert(!schemaFile.exists, "Schema file exists")
+}
+
+TaskKey[Unit]("check") := {
+  val schemaFile = (sangriaSchemagen in Compile).value
+  val expected   = StarWarsDir / "schema.graphql"
+
+  assert(schemaFile == (sangriaSchemagenSchema in Compile).value)
+  assert(schemaFile.exists, "Schema file does not exists")
+
+  val compare = IO.read(schemaFile).trim == IO.read(expected).trim
+  if (!compare)
+    s"diff -u $expected $schemaFile".!
+  assert(compare, s"$schemaFile does not equal $expected")
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/project/SangriaSchemagenPlugin.scala-
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/project/SangriaSchemagenPlugin.scala-
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 Mediative
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.sbt
+
+import sbt._
+import sbt.Keys._
+
+object BuildInfo {
+  val scalaVersion = "2.12.2"
+  val scalaBinaryVersion = "2.12"
+  val version = "0.0.5"
+}
+/**
+ * Generate API code based on a GraphQL schema and queries.
+ *
+ * == Usage ==
+ *
+ * This plugin must be explicitly enabled. To enable it add the following line
+ * to your `.sbt` file:
+ * {{{
+ * enablePlugins(SangriaCodegenPlugin)
+ * }}}
+ *
+ * By default, the plugin reads `*.graphql` files from the resources directory
+ * and generates a single Scala source files in the managed source directory.
+ *
+ * See the [[https://github.com/mediative/sangria-codegen/tree/master/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate example project]].
+ *
+ * == Configuration ==
+ *
+ * Keys are defined in [[SangriaCodegenPlugin.autoImport]].
+ *
+ *  - `sangriaSchemagenSchema`: The GraphQL schema file. *
+ *  - `sangriaSchemagenQueries`: GraphQL query documents. Defaults to `*.graphql`
+ *   files found inside  which are found inside the resources directory.
+ *
+ *  - `resourceDirectories in sangriaSchemagen`: The resource directories in which
+ *    to search for GraphQL query documents.
+ *
+ *  - `includeFilter in sangriaSchemagen`: Filter which query documents to include.
+ *    Defaults to `"*.graphql"`.
+ *
+ *  - `excludeFilter in sangriaSchemagen`: Filter out query documents.
+ *    Defaults to `HiddenFileFilter`.
+ *
+ *  - `name in sangriaSchemagen`: Name of the enclosing object.
+ *
+ * @example
+ * {{{
+ * sangriaSchemagenSchema := sourceDirectory.value / "graphql" / "schema.graphql"
+ * sangriaSchemagenQueries += sourceDirectory.value / "graphql" / "api.graphql"
+ * }}}
+ */
+object SangriaSchemagenPlugin extends AutoPlugin {
+
+  object autoImport {
+    val SangriaSchemagen     = config("sangria-schemagen") extend Compile
+    val sangriaSchemagenCode = taskKey[Option[String]]("Code to access the GraphQL Schema")
+    val sangriaSchemagenSchema = taskKey[File]("Code to access the GraphQL Schema")
+    val sangriaSchemagenLauncher = taskKey[File]("Generate GraphQL schema program")
+    val sangriaSchemagen     = taskKey[File]("Generate GraphQL schema file")
+  }
+  import autoImport._
+
+  override def requires = plugins.JvmPlugin
+
+  /**
+   * Add the IntegrationTest config to the project. The `extend(Test)`
+   * part makes it so classes in src/it have a classpath dependency on
+   * classes in src/test. This makes it simple to share common test
+   * helper code.
+   *
+   * See [[http://www.scala-sbt.org/release/docs/Testing.html#Custom+test+configuration]]
+   */
+  //override val projectConfigurations = Seq(SangriaSchemagen)
+
+  override def projectSettings: Seq[Setting[_]] =
+    sangriaSchemagenScopedSettings(SangriaSchemagen) ++ sangriaSchemagenDefaultSettings
+
+  def sangriaSchemagenDefaultSettings: Seq[Setting[_]] = Seq(
+    ivyConfigurations += SangriaSchemagen
+  )
+
+  def sangriaSchemagenScopedSettings(conf: Configuration): Seq[Setting[_]] =
+    inConfig(conf)(
+      Defaults.compileSettings ++
+      Seq(
+        sourceGenerators += Def.task {
+          val schemaCode = (sangriaSchemagenCode in Compile).value.get
+          val schemaFile = (sangriaSchemagenSchema in Compile).value
+          val file       = (sourceManaged in SangriaSchemagen).value / "sbt-sangria-codegen" / "SangriaSchemagen.scala"
+          val content = s"""
+            package com.mediative.sangria.codegen
+
+            object SangriaSchemagen {
+              val schema: sangria.schema.Schema[_, _] = {
+                $schemaCode
+              }
+
+              def main(args: Array[String]): Unit = {
+                val schemaFile = new java.io.File("${schemaFile.getAbsolutePath}")
+                println("Generating schema in ${schemaFile.getAbsolutePath}")
+                val graphql: String = schema.renderPretty
+                schemaFile.getParentFile.mkdirs()
+                new java.io.PrintWriter(schemaFile) {
+                  write(graphql)
+                  close
+                }
+              }
+            }
+          """
+          if (!file.exists || IO.read(file) != content)
+            IO.write(file, content)
+          Seq(file)
+        },
+        sangriaSchemagenSchema in Compile := (resourceManaged in Compile).value / "sbt-sangria-codegen" / "schema.graphql",
+        sangriaSchemagen := {
+          val x = runTask(conf, "com.mediative.sangria.codegen.SangriaSchemagen").value
+          (sangriaSchemagenSchema in Compile).value
+        }
+      ))
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/project/plugins.sbt
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.mediative" % "sbt-sangria-codegen" % sys.props("project.version"))

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/src/main/scala/com.mediative.sangria.codegen.starwars/TestData.scala
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/src/main/scala/com.mediative.sangria.codegen.starwars/TestData.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Oleg Ilyenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.starwars
+
+import sangria.execution.deferred.{Deferred, DeferredResolver}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+object TestData {
+  object Episode extends Enumeration {
+    val NEWHOPE, EMPIRE, JEDI = Value
+  }
+
+  trait Character {
+    def id: String
+    def name: Option[String]
+    def friends: List[String]
+    def appearsIn: List[Episode.Value]
+  }
+
+  case class Human(
+      id: String,
+      name: Option[String],
+      friends: List[String],
+      appearsIn: List[Episode.Value],
+      homePlanet: Option[String])
+      extends Character
+  case class Droid(
+      id: String,
+      name: Option[String],
+      friends: List[String],
+      appearsIn: List[Episode.Value],
+      primaryFunction: Option[String])
+      extends Character
+
+  case class DeferFriends(friends: List[String]) extends Deferred[List[Option[Character]]]
+
+  val characters = List[Character](
+    Human(
+      id = "1000",
+      name = Some("Luke Skywalker"),
+      friends = List("1002", "1003", "2000", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Tatooine")
+    ),
+    Human(
+      id = "1001",
+      name = Some("Darth Vader"),
+      friends = List("1004"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Tatooine")),
+    Human(
+      id = "1002",
+      name = Some("Han Solo"),
+      friends = List("1000", "1003", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = None),
+    Human(
+      id = "1003",
+      name = Some("Leia Organa"),
+      friends = List("1000", "1002", "2000", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = Some("Alderaan")
+    ),
+    Human(
+      id = "1004",
+      name = Some("Wilhuff Tarkin"),
+      friends = List("1001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      homePlanet = None),
+    Droid(
+      id = "2000",
+      name = Some("C-3PO"),
+      friends = List("1000", "1002", "1003", "2001"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      primaryFunction = Some("Protocol")
+    ),
+    Droid(
+      id = "2001",
+      name = Some("R2-D2"),
+      friends = List("1000", "1002", "1003"),
+      appearsIn = List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI),
+      primaryFunction = Some("Astromech")
+    )
+  )
+
+  class FriendsResolver extends DeferredResolver[Any] {
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(
+        implicit ec: ExecutionContext) = deferred map {
+      case DeferFriends(friendIds) ⇒
+        Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
+    }
+  }
+
+  class CharacterRepo {
+    def getHero(episode: Option[Episode.Value]) =
+      episode flatMap (_ ⇒ getHuman("1000")) getOrElse characters.last
+
+    def getHuman(id: String): Option[Human] =
+      characters.find(c ⇒ c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
+
+    def getDroid(id: String): Option[Droid] =
+      characters.find(c ⇒ c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
+
+    def getCharacters(ids: Seq[String]): Seq[Character] =
+      ids.flatMap(id ⇒ characters.find(_.id == id))
+  }
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/src/main/scala/com.mediative.sangria.codegen.starwars/TestSchema.scala
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/src/main/scala/com.mediative.sangria.codegen.starwars/TestSchema.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 Oleg Ilyenko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mediative.sangria.codegen.starwars
+
+import sangria.execution.UserFacingError
+import sangria.schema._
+
+import scala.concurrent.Future
+
+object TestSchema {
+  import TestData._
+
+  case class PrivacyError(message: String) extends Exception(message) with UserFacingError
+
+  val EpisodeEnum = EnumType(
+    "Episode",
+    Some("One of the films in the Star Wars Trilogy"),
+    List(
+      EnumValue(
+        "NEWHOPE",
+        value = TestData.Episode.NEWHOPE,
+        description = Some("Released in 1977.")),
+      EnumValue("EMPIRE", value = TestData.Episode.EMPIRE, description = Some("Released in 1980.")),
+      EnumValue("JEDI", value = TestData.Episode.JEDI, description = Some("Released in 1983."))))
+
+  val Character: InterfaceType[Unit, TestData.Character] =
+    InterfaceType(
+      "Character",
+      "A character in the Star Wars Trilogy",
+      () ⇒
+        fields[Unit, TestData.Character](
+          Field("id", StringType, Some("The id of the character."), resolve = _.value.id),
+          Field(
+            "name",
+            OptionType(StringType),
+            Some("The name of the character."),
+            resolve = _.value.name),
+          Field(
+            "friends",
+            OptionType(ListType(OptionType(Character))),
+            Some("The friends of the character, or an empty list if they have none."),
+            resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+          ),
+          Field(
+            "appearsIn",
+            OptionType(ListType(OptionType(EpisodeEnum))),
+            Some("Which movies they appear in."),
+            resolve = _.value.appearsIn map (e ⇒ Some(e))),
+          Field(
+            "secretBackstory",
+            OptionType(StringType),
+            Some("Where are they from and how they came to be who they are."),
+            resolve = _ ⇒ throw PrivacyError("secretBackstory is secret.")
+          )
+      ))
+
+  val Human =
+    ObjectType(
+      "Human",
+      "A humanoid creature in the Star Wars universe.",
+      interfaces[Unit, Human](PossibleInterface[Unit, Human](Character)),
+      fields[Unit, Human](
+        Field("id", StringType, Some("The id of the human."), resolve = _.value.id),
+        Field(
+          "name",
+          OptionType(StringType),
+          Some("The name of the human."),
+          resolve = _.value.name),
+        Field(
+          "friends",
+          OptionType(ListType(OptionType(Character))),
+          Some("The friends of the human, or an empty list if they have none."),
+          resolve = (ctx) ⇒ DeferFriends(ctx.value.friends)
+        ),
+        Field(
+          "appearsIn",
+          OptionType(ListType(OptionType(EpisodeEnum))),
+          Some("Which movies they appear in."),
+          resolve = _.value.appearsIn map (e ⇒ Some(e))),
+        Field(
+          "homePlanet",
+          OptionType(StringType),
+          Some("The home planet of the human, or null if unknown."),
+          resolve = _.value.homePlanet)
+      )
+    )
+
+  val Droid = ObjectType(
+    "Droid",
+    "A mechanical creature in the Star Wars universe.",
+    interfaces[Unit, Droid](PossibleInterface[Unit, Droid](Character)),
+    fields[Unit, Droid](
+      Field(
+        "id",
+        StringType,
+        Some("The id of the droid."),
+        tags = ProjectionName("_id") :: Nil,
+        resolve = _.value.id),
+      Field(
+        "name",
+        OptionType(StringType),
+        Some("The name of the droid."),
+        resolve = ctx ⇒ Future.successful(ctx.value.name)),
+      Field(
+        "friends",
+        OptionType(ListType(OptionType(Character))),
+        Some("The friends of the droid, or an empty list if they have none."),
+        resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+      ),
+      Field(
+        "appearsIn",
+        OptionType(ListType(OptionType(EpisodeEnum))),
+        Some("Which movies they appear in."),
+        resolve = _.value.appearsIn map (e ⇒ Some(e))),
+      Field(
+        "primaryFunction",
+        OptionType(StringType),
+        Some("The primary function of the droid."),
+        resolve = _.value.primaryFunction)
+    )
+  )
+
+  val ID = Argument("id", StringType, description = "id of the character")
+
+  val EpisodeArg = Argument(
+    "episode",
+    OptionInputType(EpisodeEnum),
+    description =
+      "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.")
+
+  val Query = ObjectType[CharacterRepo, Unit](
+    "Query",
+    fields[CharacterRepo, Unit](
+      Field(
+        "hero",
+        Character,
+        arguments = EpisodeArg :: Nil,
+        resolve = (ctx) ⇒ ctx.ctx.getHero(ctx.arg(EpisodeArg))),
+      Field(
+        "human",
+        OptionType(Human),
+        arguments = ID :: Nil,
+        resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
+      Field(
+        "droid",
+        Droid,
+        arguments = ID :: Nil,
+        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+    ))
+
+  val StarWarsSchema = Schema(Query)
+}

--- a/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/test
+++ b/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema/test
@@ -1,0 +1,3 @@
+> update
+> checkBefore
+> check


### PR DESCRIPTION
Generate GraphQL schema file from a Sangria schema instance.

#### Usage

This plugin must be explicitly enabled. To enable it add the following line
to your `.sbt` file:
```sbt
enablePlugins(SangriaSchemagenPlugin)
```

In addition, it is required to configure `sangriaSchemagenCode` with a snippet
of Scala code providing access to your `sangria.schema.Schema[_, _]`.

See the [[https://github.com/mediative/sangria-codegen/tree/master/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema example project]].

#### Using with [[SangriaCodegenPlugin]]

To use this plugin to generate a schema for use with [[SangriaCodegenPlugin]]
they must be configured in separate projects. For example, [[SangriaSchemagenPlugin]]
could be enabled in the server project which defines the Sangria schema, and
[[SangriaCodegenPlugin]] will be enabled in the client project which consumes
the GraphQL services.

See the [[https://github.com/mediative/sangria-codegen/tree/master/sbt-sangria-codegen/src/sbt-test/sangria-codegen/generate-schema-and-code example project]].

#### Implementation Details

The plugins introduces a parallel build scope named `sangria-schemagen` and
uses it for generating a program for executing the schema introspection code
defined in `sangriaSchemagenSnippet`. The build scope depends on the normal
`compile` scope so schema classes are available when running the program.
Generate code can be found in `target/scala-2.x/src_managed/sangria-schemagen`
and compile artifacts can be found in `target/scala-2.x/sangria-schemagen-classes`.

#### Configuration

Keys are defined in [[SangriaSchemagenPlugin.autoImport]].

 - `sangriaSchemagenSnippet`: Code snippet to access the Sangria Schema.
 - `sangriaSchemagenSchema`: GraphQL schema output file. Defaults to
   file located inside `resourceManaged`.
 - `sangriaSchemagen`: Generate the GraphQL schema file.

Example:
```sbt
sangriaSchemagenSnippet in Compile := Some("com.example.schema.GraphqlSchema")
sangriaSchemagenSchema in Compile := (resourceDirectory in Compile).value / "schema.graphql"
```
