### PR TITLE
Force unit value to avoid compiler warning

### DIFF
--- a/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
+++ b/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
@@ -142,6 +142,7 @@ object SangriaSchemagenPlugin extends AutoPlugin {
                       write(graphql)
                       close
                     }
+                    ()
                   }
                 }
               """

--- a/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
+++ b/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala
@@ -110,7 +110,7 @@ object SangriaSchemagenPlugin extends AutoPlugin {
             streams.value.log
           )
 
-          streams.value.log.info("Generating schema in $schemaFile")
+          streams.value.log.info(s"Generating schema in $schemaFile")
           schemaFile
         }
       )


### PR DESCRIPTION
    [error] .../target/scala-2.11/src_managed/sangria-schemagen/sbt-sangria-codegen/SangriaSchemagen.scala:13:
    discarded non-Unit value
    [error]                     new java.io.PrintWriter(schemaFile) {
    [error]                     ^
    [error] one error found